### PR TITLE
Ooverride the default behaivor of the updateResult

### DIFF
--- a/src/main/java/com/aventstack/extentreports/cucumber/adapter/ExtentCucumberAdapter.java
+++ b/src/main/java/com/aventstack/extentreports/cucumber/adapter/ExtentCucumberAdapter.java
@@ -60,7 +60,7 @@ public class ExtentCucumberAdapter
     private static ThreadLocal<ExtentTest> scenarioOutlineThreadLocal = new InheritableThreadLocal<>();
     private static ThreadLocal<ExtentTest> scenarioThreadLocal = new InheritableThreadLocal<>();
     private static ThreadLocal<Boolean> isHookThreadLocal = new InheritableThreadLocal<>();
-    private static ThreadLocal<ExtentTest> stepTestThreadLocal = new InheritableThreadLocal<>();
+    protected static ThreadLocal<ExtentTest> stepTestThreadLocal = new InheritableThreadLocal<>();
     
     private String screenshotDir;
     private String screenshotRelPath;
@@ -181,7 +181,7 @@ public class ExtentCucumberAdapter
         updateResult(event.result);
     }
     
-    private synchronized void updateResult(Result result) {
+    protected synchronized void updateResult(Result result) {
         switch (result.getStatus().lowerCaseName()) {
             case "failed":
                 stepTestThreadLocal.get().fail(result.getError());


### PR DESCRIPTION
Hello, 

Right now this class is completely private, It would be useful if at least the update Result method is protected, This way I can customize the default behavior, for example right now I want to make use of the rest of cucumber status: error, warning .. etc